### PR TITLE
APP_NAME incorrectly trimed

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -2,7 +2,7 @@ def template = 'https://raw.githubusercontent.com/sabre1041/image-scanning-signi
 
 openshift.withCluster() {
   env.NAMESPACE =  openshift.project()
-  env.APP_NAME = "${env.JOB_NAME}".replaceAll(/-?${NAMESPACE}-?/, '').replaceAll(/-?pipeline-?/, '')
+  env.APP_NAME = "${env.JOB_NAME}".replaceAll(/-?${NAMESPACE}-?/, '').replaceAll(/-?pipeline-?/, '').replace("/", "")
 }
 
 pipeline {


### PR DESCRIPTION
-o name on oc client 3.7+ returns an extra "/" in name making the pipeline to fail