### PR TITLE
Updates for use in disconnected environments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ roles
 .DS_Store
 deploy
 tmp
+galaxy
 

--- a/README.md
+++ b/README.md
@@ -282,3 +282,8 @@ Once successful, the stage view will appear similar to the following:
 Back within the OpenShift web console, locate the address of the exposed _Route_ to access the application by hovering over _Applications_  on the lefthand navigation bar and selecting **Routes**. Click on the URL provided underneath _Hostname_.
 
 To learn more about the underlying steps that are executed within the pipeline, browse through the included [Jenkinsfile](ci/Jenkinsfile).
+
+## Known Issues
+
+* Currently, the latest version of the `image-inspector` binary suffers from a bug causing reduced functionality.
+The `--openscap-html-report` option mishandles the parsing of the `results-arf.xml` in `image-sign-scan-base` This casues the execution of image scans to fail. A workaround has been applied to the `image-sign-scan-base` image to ignore this flag. Reduced functionality of no HTML report generation for all image scan requests is expected until the upstream `image-inspector` is fixed. Please see https://github.com/openshift/image-inspector/issues/105

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,10 +1,11 @@
-def template = 'https://raw.githubusercontent.com/sabre1041/image-scanning-signing-service/master/examples/image-signing-request-template.yml'
-def scanTemplate = 'https://raw.githubusercontent.com/sabre1041/image-scanning-signing-service/master/examples/image-scanning-request-template.yml'
+def template = 'https://raw.githubusercontent.com/redhat-cop/image-scanning-signing-service/master/examples/image-signing-request-template.yml'
+def scanTemplate = 'https://raw.githubusercontent.com/redhat-cop/image-scanning-signing-service/master/examples/image-scanning-request-template.yml'
 
 
 openshift.withCluster() {
   env.NAMESPACE =  openshift.project()
   env.APP_NAME = "${env.JOB_NAME}".replaceAll(/-?${env.NAMESPACE}-?/, '').replaceAll(/-?pipeline-?/, '').replaceAll('/', '')
+  echo "begin build of " + env.APP_NAME
 }
 
 pipeline {

--- a/files/builds/image-scanning-signing-pipeline/template.yml
+++ b/files/builds/image-scanning-signing-pipeline/template.yml
@@ -75,7 +75,7 @@ parameters:
 - description: Git source URI for application
   name: PIPELINE_REPOSITORY_URL
   required: true
-  value: https://github.com/sabre1041/image-scanning-signing-service.git
+  value: https://github.com/redhat-cop/image-scanning-signing-service.git
 - description: Git branch/tag reference
   name: PIPELINE_REPOSITORY_REF
   value: "master"

--- a/files/builds/image-scanning-signing-service/template.yml
+++ b/files/builds/image-scanning-signing-service/template.yml
@@ -55,7 +55,7 @@ parameters:
 - description: Git source URL for application
   name: SOURCE_REPOSITORY_URL
   required: true
-  value: https://github.com/sabre1041/image-scanning-signing-service
+  value: https://github.com/redhat-cop/image-scanning-signing-service
 - description: Go Import Path
   name: GO_IMPORT_PATH
   required: true

--- a/files/builds/image-sign-scan-base/template.yml
+++ b/files/builds/image-sign-scan-base/template.yml
@@ -50,11 +50,11 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: FROM_IMAGE
   required: true
-  value: rhel7:7.5
+  value: image-inspector:latest
 - name: VERSION
   displayName: OpenShift Container Platform Version
   description: Version of the OpenShift Container Platform
-  value: "3.9"
+  value: "3.11"
   required: true
 - description: Git branch/tag reference
   name: SOURCE_REPOSITORY_REF
@@ -62,7 +62,7 @@ parameters:
 - description: Git source URL for application
   name: SOURCE_REPOSITORY_URL
   required: true
-  value: https://github.com/sabre1041/image-scanning-signing-service
+  value: https://github.com/redhat-cop/image-scanning-signing-service
 - description: Path within Git repository to build; empty for root of repository
   name: CONTEXT_DIR
   value: images/image-sign-scan-base

--- a/files/builds/image-sign-scan-base/template.yml
+++ b/files/builds/image-sign-scan-base/template.yml
@@ -50,11 +50,11 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: FROM_IMAGE
   required: true
-  value: image-inspector:latest
+  value: openshift3/image-inspector:latest
 - name: VERSION
   displayName: OpenShift Container Platform Version
   description: Version of the OpenShift Container Platform
-  value: "3.9"
+  value: "3.11"
   required: true
 - description: Git branch/tag reference
   name: SOURCE_REPOSITORY_REF
@@ -62,7 +62,7 @@ parameters:
 - description: Git source URL for application
   name: SOURCE_REPOSITORY_URL
   required: true
-  value: https://github.com/sabre1041/image-scanning-signing-service
+  value: https://github.com/redhat-cop/image-scanning-signing-service
 - description: Path within Git repository to build; empty for root of repository
   name: CONTEXT_DIR
   value: images/image-sign-scan-base

--- a/files/builds/image-sign-scan-base/template.yml
+++ b/files/builds/image-sign-scan-base/template.yml
@@ -50,7 +50,7 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: FROM_IMAGE
   required: true
-  value: openshift3/image-inspector:latest
+  value: image-inspector:latest
 - name: VERSION
   displayName: OpenShift Container Platform Version
   description: Version of the OpenShift Container Platform

--- a/files/builds/image-sign-scan-base/template.yml
+++ b/files/builds/image-sign-scan-base/template.yml
@@ -50,7 +50,7 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: FROM_IMAGE
   required: true
-  value: rhel7:7.5
+  value: image-inspector:latest
 - name: VERSION
   displayName: OpenShift Container Platform Version
   description: Version of the OpenShift Container Platform

--- a/files/builds/s2i-golang/template.yml
+++ b/files/builds/s2i-golang/template.yml
@@ -51,7 +51,7 @@ parameters:
 - description: Git source URL for application
   name: SOURCE_REPOSITORY_URL
   required: true
-  value: https://github.com/sabre1041/image-scanning-signing-service
+  value: https://github.com/redhat-cop/image-scanning-signing-service
 - description: Path within Git repository to build; empty for root of repository
   name: CONTEXT_DIR
   value: images/s2i-golang

--- a/files/imagestreams/images.yml
+++ b/files/imagestreams/images.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ImageStream
 metadata:
-  name: rhel7
+  name: image-inspector
 spec:
-  dockerImageRepository: registry.access.redhat.com/rhel7/rhel
+  dockerImageRepository: registry.access.redhat.com/openshift3/image-inspector

--- a/files/imagestreams/images.yml
+++ b/files/imagestreams/images.yml
@@ -1,6 +1,21 @@
 apiVersion: v1
-kind: ImageStream
+kind: Template
 metadata:
-  name: image-inspector
-spec:
-  dockerImageRepository: registry.access.redhat.com/openshift3/image-inspector
+  name: base-image-template
+  annotations:
+    openshift.io/display-name: Image Signing and Scanning Base
+    description: Template to create base imagestreams for image-management
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: image-inspector
+  spec:
+    dockerImageRepository: registry.access.redhat.com/openshift3/image-inspector
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: rhel7
+  spec:
+    dockerImageRepository: registry.access.redhat.com/rhel7/rhel 
+

--- a/files/imagestreams/images.yml
+++ b/files/imagestreams/images.yml
@@ -1,6 +1,21 @@
 apiVersion: v1
-kind: ImageStream
+kind: Template
 metadata:
-  name: rhel7
-spec:
-  dockerImageRepository: registry.access.redhat.com/rhel7/rhel
+  name: base-image-template
+  annotations:
+    openshift.io/display-name: Image Signing and Scanning Base
+    description: Template to create base imagestreams for image-management
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: image-inspector
+  spec:
+    dockerImageRepository: registry.access.redhat.com/openshift3/image-inspector
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: rhel7
+  spec:
+    dockerImageRepository: registry.access.redhat.com/rhel7/rhel 
+

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7/rhel
+FROM registry.access.redhat.com/openshift3/image-inspector:latest
 
 ARG OCP_VERSION=3.9
 
@@ -7,7 +7,7 @@ ADD bin/sign-image bin/scan-image /usr/local/bin/
 RUN rpm -ihv https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum repolist > /dev/null && \
     yum clean all && \
-    INSTALL_PKGS="docker atomic jq atomic-openshift-clients image-inspector tar" && \
+    INSTALL_PKGS="docker atomic jq atomic-openshift-clients tar" && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,6 +1,7 @@
 FROM openshift/image-inspector:latest
 
 ARG OCP_VERSION
+ENV OCP_VERSION ${OCP_VERSION:3.10}
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,13 +1,17 @@
-FROM registry.access.redhat.com/rhel7/rhel
+FROM openshift3/image-inspector:latest
 
-ARG OCP_VERSION=3.9
+ARG OCP_VERSION
+ENV OCP_VERSION ${OCP_VERSION:-3.10}
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
-RUN rpm -ihv https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum repolist > /dev/null && \
+# The curl install of JQ is required in order to bypass requiring the EPEL repository. The URL can be mirrored in disconnected environments.
+RUN yum repolist > /dev/null && \
+    curl -o jq -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
+    chmod +x ./jq && \
+    cp jq /usr/bin && \
     yum clean all && \
-    INSTALL_PKGS="docker atomic jq atomic-openshift-clients image-inspector tar" && \
+    INSTALL_PKGS="docker atomic atomic-openshift-clients tar" && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM openshift/image-inspector:latest
 
-#ARG OCP_VERSION=3.11
+ARG OCP_VERSION
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
@@ -10,7 +10,8 @@ RUN yum repolist > /dev/null && \
     cp jq /usr/bin && \
     yum clean all && \
     INSTALL_PKGS="docker atomic atomic-openshift-clients tar" && \
-#    yum install -y --enablerepo=rhel-7-server-ose-3.8-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs image-inspector && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
+
+#    yum install -y --enablerepo=rhel-7-server-ose-3.8-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs image-inspector && \

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -5,7 +5,7 @@ ARG OCP_VERSION=3.9
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
 RUN yum repolist > /dev/null && \
-    wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
+    curl -o jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
     chmod +x ./jq && \
     cp jq /usr/bin && \
     yum clean all && \

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,7 +1,7 @@
 FROM openshift/image-inspector:latest
 
 ARG OCP_VERSION
-ENV OCP_VERSION ${OCP_VERSION:3.10}
+ENV OCP_VERSION ${OCP_VERSION:-3.10}
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM openshift/image-inspector:latest
 
-ARG OCP_VERSION=${OCP_VERSION}
+ENV OCP_VERSION=3.11
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
@@ -10,7 +10,7 @@ RUN yum repolist > /dev/null && \
     cp jq /usr/bin && \
     yum clean all && \
     INSTALL_PKGS="docker atomic atomic-openshift-clients tar" && \
-    yum install -y --enablerepo=rhel-7-server-ose-3.8-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs image-inspector && \
+#    yum install -y --enablerepo=rhel-7-server-ose-3.8-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs image-inspector && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,10 +1,11 @@
-FROM openshift/image-inspector:latest
+FROM openshift3/image-inspector:latest
 
 ARG OCP_VERSION
 ENV OCP_VERSION ${OCP_VERSION:-3.10}
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
+# The curl install of JQ is required in order to bypass requiring the EPEL repository. The URL can be mirrored in disconnected environments.
 RUN yum repolist > /dev/null && \
     curl -o jq -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
     chmod +x ./jq && \
@@ -14,5 +15,3 @@ RUN yum repolist > /dev/null && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
-
-#    yum install -y --enablerepo=rhel-7-server-ose-3.8-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs image-inspector && \

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM openshift/image-inspector:latest
 
-ENV OCP_VERSION=3.11
+#ARG OCP_VERSION=3.11
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -5,8 +5,11 @@ ARG OCP_VERSION=3.9
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
 RUN yum repolist > /dev/null && \
+    wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
+    chmod +x ./jq && \
+    cp jq /usr/bin && \
     yum clean all && \
-    INSTALL_PKGS="docker atomic jq atomic-openshift-clients tar" && \
+    INSTALL_PKGS="docker atomic atomic-openshift-clients tar" && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -5,7 +5,7 @@ ARG OCP_VERSION=3.9
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
 RUN yum repolist > /dev/null && \
-    curl -o jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
+    curl -o jq -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
     chmod +x ./jq && \
     cp jq /usr/bin && \
     yum clean all && \

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -4,8 +4,7 @@ ARG OCP_VERSION=3.9
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
-RUN rpm -ihv https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum repolist > /dev/null && \
+RUN yum repolist > /dev/null && \
     yum clean all && \
     INSTALL_PKGS="docker atomic jq atomic-openshift-clients tar" && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,6 +1,7 @@
-FROM registry.access.redhat.com/openshift3/image-inspector:latest
+FROM openshift/image-inspector:latest
 
-ARG OCP_VERSION=3.9
+ARG OCP_VERSION
+ENV OCP_VERSION ${OCP_VERSION:-3.10}
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 
@@ -13,3 +14,5 @@ RUN yum repolist > /dev/null && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
+
+#    yum install -y --enablerepo=rhel-7-server-ose-3.8-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs image-inspector && \

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,6 +1,6 @@
-FROM rhel7:latest
+FROM openshift/image-inspector:latest
 
-ARG OCP_VERSION=3.9
+ARG OCP_VERSION=${OCP_VERSION}
 
 ADD bin/sign-image bin/scan-image /usr/local/bin/
 

--- a/images/image-sign-scan-base/Dockerfile
+++ b/images/image-sign-scan-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/image-inspector:latest
+FROM rhel7:latest
 
 ARG OCP_VERSION=3.9
 
@@ -10,6 +10,7 @@ RUN yum repolist > /dev/null && \
     cp jq /usr/bin && \
     yum clean all && \
     INSTALL_PKGS="docker atomic atomic-openshift-clients tar" && \
+    yum install -y --enablerepo=rhel-7-server-ose-3.8-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs image-inspector && \
     yum install -y --enablerepo=rhel-7-server-ose-${OCP_VERSION}-rpms --enablerepo=rhel-7-server-extras-rpms --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/images/image-sign-scan-base/bin/scan-image
+++ b/images/image-sign-scan-base/bin/scan-image
@@ -15,4 +15,4 @@ DOCKERCFG_SECRET_NAME=$(echo "${SA_JSON}" | jq -r ".imagePullSecrets[] | select(
 
 oc get secret -n $NAMESPACE $DOCKERCFG_SECRET_NAME -o json | jq -r ".data[] | select(\".dockercfg\")" | base64 -d > $DOCKER_CFG_HOME/.dockercfg
 
-image-inspector -chroot --path=${IMAGE_CONTENT} --scan-results-dir=${RESULTS} --scan-type=openscap --openscap-html-report --dockercfg=$DOCKER_CFG_HOME/.dockercfg --image=$IMAGE -serve=0.0.0.0:8080
+image-inspector -chroot --path=${IMAGE_CONTENT} --scan-results-dir=${RESULTS} --scan-type=openscap  --dockercfg=$DOCKER_CFG_HOME/.dockercfg --image=$IMAGE -serve=0.0.0.0:8080

--- a/images/image-sign-scan-base/bin/scan-image
+++ b/images/image-sign-scan-base/bin/scan-image
@@ -15,4 +15,4 @@ DOCKERCFG_SECRET_NAME=$(echo "${SA_JSON}" | jq -r ".imagePullSecrets[] | select(
 
 oc get secret -n $NAMESPACE $DOCKERCFG_SECRET_NAME -o json | jq -r ".data[] | select(\".dockercfg\")" | base64 -d > $DOCKER_CFG_HOME/.dockercfg
 
-image-inspector -chroot --path=${IMAGE_CONTENT} --scan-results-dir=${RESULTS} --scan-type=openscap --openscap-html-report --dockercfg=$DOCKER_CFG_HOME/.dockercfg --image=$IMAGE -serve=0.0.0.0:8080
+image-inspector -chroot --path=${IMAGE_CONTENT} --scan-results-dir=${RESULTS} --scan-type=openscap  --dockercfg=$DOCKER_CFG_HOME/.dockercfg --image=$IMAGE -serve=0.0.0.0:8080 -v 10

--- a/images/image-sign-scan-base/bin/scan-image
+++ b/images/image-sign-scan-base/bin/scan-image
@@ -15,4 +15,4 @@ DOCKERCFG_SECRET_NAME=$(echo "${SA_JSON}" | jq -r ".imagePullSecrets[] | select(
 
 oc get secret -n $NAMESPACE $DOCKERCFG_SECRET_NAME -o json | jq -r ".data[] | select(\".dockercfg\")" | base64 -d > $DOCKER_CFG_HOME/.dockercfg
 
-image-inspector -chroot --path=${IMAGE_CONTENT} --scan-results-dir=${RESULTS} --scan-type=openscap  --dockercfg=$DOCKER_CFG_HOME/.dockercfg --image=$IMAGE -serve=0.0.0.0:8080 -v 10
+image-inspector -chroot --path=${IMAGE_CONTENT} --scan-results-dir=${RESULTS} --scan-type=openscap  --dockercfg=$DOCKER_CFG_HOME/.dockercfg --image=$IMAGE -serve=0.0.0.0:8080

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -50,8 +50,9 @@
             - core
     - object: imagestreams
       content:
-        - name: rhel
-          file: "{{ inventory_dir }}/../files/imagestreams/images.yml"
+        - name: images
+          template: "{{ inventory_dir }}/../files/imagestreams/images.yml"
+          params: "{{ inventory_dir }}/../files/imagestreams/params"
           namespace: "image-management"
           tags:
             - core

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -499,7 +499,7 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 						}
 					}
 
-					logrus.Infof("Scanning Pod Succeeded. Updating ImageSiginingRequest %s", pod.Annotations[common.CopOwnerAnnotation])
+					logrus.Infof("Scanning Pod Succeeded. Updating ImageScanningRequest %s", pod.Annotations[common.CopOwnerAnnotation])
 
 					err = scanning.UpdateOnImageScanningCompletionSuccess("Image Scanned", totalRules, passedRules, failedRules, *imageScanningRequest)
 
@@ -515,7 +515,7 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 					}
 
 				} else {
-					logrus.Infof("Scanning Health Check Could Not Be Validated. Updating ImageSiginingRequest %s", podOwnerAnnotation)
+					logrus.Infof("Scanning Health Check Could Not Be Validated. Updating ImageScanningRequest %s", podOwnerAnnotation)
 
 					err = scanning.UpdateOnImageScanningCompletionError("Health Check Validation Error", *imageScanningRequest)
 


### PR DESCRIPTION
Fixes git repository URLS
Remove dependency on EPEL (for use in disconnected installs)
Use image-inspector base image instead of installing it as a package